### PR TITLE
Add Amplify Auth login modal

### DIFF
--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -1,14 +1,34 @@
-import { Box, Flex, Heading, Spacer, Button, Image } from '@chakra-ui/react';
-import logo from './images/logo.webp'; // adjust the path if the file is in public/
-
-// ...
-
+import { useEffect } from 'react';
+import {
+  Box,
+  Flex,
+  Heading,
+  Spacer,
+  Button,
+  Image,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalCloseButton,
+  ModalBody,
+  useDisclosure,
+} from '@chakra-ui/react';
+import { Authenticator, useAuthenticator } from '@aws-amplify/ui-react';
+import logo from './images/logo.webp';
 
 
 export default function Header() {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const { user, signOut } = useAuthenticator((ctx) => [ctx.user]);
+  useEffect(() => {
+    if (user) {
+      onClose();
+    }
+  }, [user, onClose]);
+
   return (
     <Box as="header" position="sticky" width="100%" top="0" zIndex="docked" bg="teal.800" boxShadow="sm">
-      <Flex align="center"  minW="960px" width="100%" maxW="960px" mx="auto" p={2}>
+      <Flex align="center" minW="960px" width="100%" maxW="960px" mx="auto" p={2}>
         <Image src={logo} alt="SnapStitch logo" boxSize="50px" borderRadius="md" mr={3} />
         <Heading
           size="2xl"
@@ -20,8 +40,19 @@ export default function Header() {
           Olive Stitch
         </Heading>
         <Spacer />
-        <Button colorScheme="teal" size="sm">Join or Sign in</Button>
+        <Button colorScheme="teal" size="sm" onClick={user ? signOut : onOpen}>
+          {user ? 'Logout' : 'Join or Sign in'}
+        </Button>
       </Flex>
+      <Modal isOpen={isOpen} onClose={onClose} isCentered>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalCloseButton />
+          <ModalBody p={4}>
+            <Authenticator />
+          </ModalBody>
+        </ModalContent>
+      </Modal>
     </Box>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,18 +6,19 @@ import { Amplify } from "aws-amplify";
 import outputs from "../amplify_outputs.json";
 import '@aws-amplify/ui-react/styles.css';
 import { ChakraProvider } from '@chakra-ui/react';
+import { Authenticator } from '@aws-amplify/ui-react';
 import { BrowserRouter } from 'react-router-dom';
 
 Amplify.configure(outputs);
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <ChakraProvider>
-      <BrowserRouter>
-        
+    <Authenticator.Provider>
+      <ChakraProvider>
+        <BrowserRouter>
           <App />
-        
-      </BrowserRouter>
-    </ChakraProvider>
+        </BrowserRouter>
+      </ChakraProvider>
+    </Authenticator.Provider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- integrate Amplify Auth with Chakra UI modal
- use `Authenticator.Provider` at app root
- toggle header button between sign in and logout

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68742396537883248fdf7d7ed01eaa13