### PR TITLE
Redirect to deep dive after creating project

### DIFF
--- a/src/Projects.tsx
+++ b/src/Projects.tsx
@@ -50,7 +50,7 @@ export default function Projects() {
 
   const handleWizardComplete = async (details: PatternDetails) => {
     if (!importImage) return;
-    await client.models.Project.create({
+    const { data } = await client.models.Project.create({
       image: importImage.src,
       pattern: JSON.stringify(details),
       progress: [],
@@ -58,6 +58,11 @@ export default function Projects() {
     await fetchProjects();
     setImportImage(null);
     if (fileInputRef.current) fileInputRef.current.value = '';
+    if (data) {
+      navigate('/deep-dive', {
+        state: { pattern: details, progress: [], id: data.id },
+      });
+    }
   };
 
   const handleWizardCancel = () => {


### PR DESCRIPTION
## Summary
- navigate to the Deep Dive experience right after creating a project

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687439b5bf188324b6d122060c015b90