### PR TITLE
Fix TS build errors by restoring Project image field

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -9,7 +9,7 @@ specifies that any user authenticated via an API key can "create", "read",
 const schema = a.schema({
   Project: a
     .model({
-      /*image: a.string(),*/
+      image: a.string(),
       pattern: a.string(),
       progress: a.string().array(),
     })


### PR DESCRIPTION
## Summary
- add `image` property back into the Amplify data schema so TS types include it

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68748c881d508324bfd103f33495ecb3