### PR TITLE
Use identityId for project images

### DIFF
--- a/src/Projects.tsx
+++ b/src/Projects.tsx
@@ -31,7 +31,8 @@ export default function Projects() {
     const records = await Promise.all(
       (data as ProjectRecord[]).map(async p => {
         if (p.image) {
-          const { url } = await getUrl({ key: p.image, options: { accessLevel: 'private' } });
+          // Images are stored in identity-scoped paths, so the default access level is sufficient
+          const { url } = await getUrl({ key: p.image });
           return { ...p, image: url.href };
         }
         return p;

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,6 +1,7 @@
 import { DMC_COLORS } from './ColorPalette';
 import { generateClient } from 'aws-amplify/data';
 import { uploadData } from '@aws-amplify/storage';
+import { fetchAuthSession } from 'aws-amplify/auth';
 import type { Schema } from '../amplify/data/resource';
 import type { PatternDetails } from './types';
 
@@ -158,11 +159,13 @@ export async function saveProject(
   pattern: PatternDetails
 ) {
   const blob = image instanceof File ? image : dataUrlToBlob(image);
-  const key = `customer-images/{entity_id}/${crypto.randomUUID()}.png`;
+  // Fetch the current Cognito identity to scope uploaded images per user
+  const { identityId } = await fetchAuthSession();
+  const key = `customer-images/${identityId}/${crypto.randomUUID()}.png`;
   const upload = await uploadData({
     key,
     data: blob,
-    options: { contentType: 'image/png', accessLevel: 'private' }
+    options: { contentType: 'image/png' }
   });
   const result = await upload.result;
   const { data } = await client.models.Project.create({


### PR DESCRIPTION
## Summary
- use `fetchAuthSession` in `saveProject` to access identityId
- store uploaded images under the user identity
- remove `accessLevel` option from storage calls

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687b0ffb82ac83249497a1304c371934