### PR TITLE
Update project save path

### DIFF
--- a/src/Projects.tsx
+++ b/src/Projects.tsx
@@ -32,7 +32,7 @@ export default function Projects() {
       (data as ProjectRecord[]).map(async p => {
         if (p.image) {
           // Images are stored in identity-scoped paths, so the default access level is sufficient
-          const { url } = await getUrl({ key: p.image });
+          const { url } = await getUrl({ path: p.image });
           return { ...p, image: url.href };
         }
         return p;


### PR DESCRIPTION
## Summary
- remove explicit identity fetch in saveProject
- scope uploaded images using `path` callback
- store returned upload path in Project records
- retrieve project images via `path`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687b1818abc483249ca8631060ceed7d