### PR TITLE
Add floss box color toggle

### DIFF
--- a/src/ColorPalette.tsx
+++ b/src/ColorPalette.tsx
@@ -461,12 +461,13 @@ export const DMC_COLORS = [
 export interface ColorPaletteProps {
   selected: string | null;
   setSelected: (hex: string) => void;
+  colors?: typeof DMC_COLORS;
 }
 
-export default function ColorPalette({ selected, setSelected }: ColorPaletteProps) {
+export default function ColorPalette({ selected, setSelected, colors = DMC_COLORS }: ColorPaletteProps) {
   return (
     <Flex wrap="wrap" gap={2} my={2} justify="center">
-      {DMC_COLORS.map(c => (
+      {colors.map(c => (
         <Box key={c.code} textAlign="center" fontSize="11px">
           <Box
             onClick={() => setSelected(c.hex)}


### PR DESCRIPTION
## Summary
- extend `ColorPalette` to accept custom color lists
- add floss-box toggle to ImportWizard color step

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npm run build` *(fails: TS2307 cannot find module 'react-router-dom', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687b204d0ac483248edb464cb02b0eb5