### PR TITLE
Refine project fetch typing

### DIFF
--- a/src/Projects.tsx
+++ b/src/Projects.tsx
@@ -42,7 +42,8 @@ export default function Projects() {
   const fetchProjects = async () => {
     const { data } = await client.models.Project.list();
     const records = await Promise.all(
-      (data as any[]).map(async (p: any) => {
+      (data as unknown[]).map(async (raw) => {
+        const p = raw as ProjectRecord;
         if (p.image) {
           // Images are stored in identity-scoped paths, so the default access level is sufficient
           const { url } = await getUrl({ path: p.image });


### PR DESCRIPTION
## Summary
- avoid `any` usage in Projects table fetcher

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687b29b167a483249e1e34e2706cb7cc