### PR TITLE
Add cross stitch symbol key

### DIFF
--- a/src/DeepDive.tsx
+++ b/src/DeepDive.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
-import { Box, Flex, Button } from '@chakra-ui/react';
+import { Box, Flex, Button, Switch, FormControl, FormLabel } from '@chakra-ui/react';
 import UsedColors from './UsedColors';
 import { getColorUsage } from './utils';
 import { DMC_COLORS } from './ColorPalette';
@@ -26,6 +26,7 @@ export default function DeepDive() {
   const [completedSections, setCompletedSections] = useState<Set<string>>(
     new Set(progress || [])
   );
+  const [showSymbols, setShowSymbols] = useState<boolean>(false);
 
   const grid = useMemo(() => pattern?.grid ?? [], [pattern]);
   const fabricCount = pattern?.fabricCount ?? 14;
@@ -155,6 +156,16 @@ export default function DeepDive() {
       <Button mb={4} onClick={() => navigate(-1)} colorScheme="teal">
         Back
       </Button>
+      <FormControl display="flex" alignItems="center" mb={4} width="fit-content">
+        <FormLabel htmlFor="symbol-toggle" mb="0">
+          Symbols
+        </FormLabel>
+        <Switch
+          id="symbol-toggle"
+          isChecked={showSymbols}
+          onChange={e => setShowSymbols(e.target.checked)}
+        />
+      </FormControl>
       <Flex gap={4} flexDir={{ base: 'column', md: 'row' }} align="flex-start">
         <Box position="relative" width={gridWidth} height={gridHeight} flexShrink={0} overflow="hidden">
           <Grid
@@ -164,6 +175,8 @@ export default function DeepDive() {
             showGrid={true}
             maxGridPx={maxGridPx}
             completedCells={completedCells}
+            symbolMap={pattern.symbols}
+            showSymbols={showSymbols}
           />
           <Box position="absolute" top={0} left={0} right={0} bottom={0}>
             {overlays}
@@ -192,6 +205,8 @@ export default function DeepDive() {
             activeCell={focusedCell}
             activeColor={focusedColor}
             markComplete={sectionComplete}
+            symbolMap={pattern.symbols}
+            showSymbols={showSymbols}
               onCellClick={(_, __, color) => {
                 setFocusedCell(null);
                 setFocusedColor(prev => (prev === color ? prev : color));
@@ -202,6 +217,8 @@ export default function DeepDive() {
                 colors={Object.keys(colorUsage)}
                 usage={colorUsage}
                 activeColor={focusedColor}
+                symbols={pattern.symbols}
+                showSymbols={showSymbols}
                 onColorClick={color => {
                   setFocusedCell(null);
                   setFocusedColor(prev => (prev === color ? prev : color));

--- a/src/Grid.tsx
+++ b/src/Grid.tsx
@@ -19,6 +19,8 @@ export interface GridProps {
   onCellClick?: (y: number, x: number, color: string | null) => void;
   markComplete?: boolean;
   completedCells?: Set<string> | null;
+  symbolMap?: Record<string, string> | null;
+  showSymbols?: boolean;
 }
 
 export default function Grid({
@@ -31,7 +33,9 @@ export default function Grid({
     activeColor = null,
     onCellClick,
   markComplete = false,
-  completedCells = null
+  completedCells = null,
+  symbolMap = null,
+  showSymbols = false
 }: GridProps) {
   const rows = grid.length;
   const cols = grid[0]?.length || 0;
@@ -66,6 +70,8 @@ export default function Grid({
       {grid.map((row, y) =>
         row.map((color, x) => {
           const dmcLabel = hexToDmc(color) || `(${x + 1}, ${y + 1})`;
+          const code = DMC_COLORS.find(c => c.hex.toLowerCase() === (color || '').toLowerCase())?.code;
+          const symbol = showSymbols && code && symbolMap ? symbolMap[code] : '';
           const colorFiltered =
             activeColor &&
             (color || '').toLowerCase() !== activeColor.toLowerCase();
@@ -81,7 +87,7 @@ export default function Grid({
               onClick={() => handleCellClick(y, x)}
               w={cellSize}
               h={cellSize}
-              bg={displayColor || '#fff'}
+              bg={showSymbols ? '#fff' : displayColor || '#fff'}
               border={showGrid ? '1px solid #ccc' : 'none'}
               boxSizing="border-box"
               cursor="pointer"
@@ -89,11 +95,17 @@ export default function Grid({
               display="flex"
               alignItems="center"
               justifyContent="center"
-              color={isComplete ? overlayShade(displayColor || '#fff') : 'inherit'}
-              fontWeight={isComplete ? 'bold' : 'normal'}
+              color={
+                isComplete
+                  ? overlayShade(displayColor || '#fff')
+                  : showSymbols
+                    ? '#000'
+                    : 'inherit'
+              }
+              fontWeight={isComplete || showSymbols ? 'bold' : 'normal'}
               title={dmcLabel}
             >
-              {isComplete ? 'X' : null}
+              {isComplete ? 'X' : symbol}
             </Box>
           );
         })

--- a/src/ImportWizard.tsx
+++ b/src/ImportWizard.tsx
@@ -32,7 +32,7 @@ import {
 
 const clamp = (v: number, min: number, max: number) => Math.min(Math.max(v, min), max);
 import Grid from './Grid';
-import { findClosestDmcColor, getColorUsage, reduceColors } from './utils';
+import { findClosestDmcColor, getColorUsage, reduceColors, generateSymbolMap } from './utils';
 import Collapsible from './Collapsible';
 import UsedColors from './UsedColors';
 import ColorPalette, { DMC_COLORS } from './ColorPalette';
@@ -51,6 +51,7 @@ export interface ImportWizardProps {
     heightIn: number;
     colors: string[];
     colorUsage: Record<string, number>;
+    symbols: Record<string, string>;
   }) => void;
 }
 
@@ -248,13 +249,15 @@ export default function ImportWizard({
   };
 
   const handleFinish = () => {
+    const colors = Object.keys(colorUsage);
     onComplete({
       grid: preview!,
       fabricCount,
       widthIn,
       heightIn,
-      colors: Object.keys(colorUsage),
-      colorUsage
+      colors,
+      colorUsage,
+      symbols: generateSymbolMap(colors)
     });
   };
 

--- a/src/UsedColors.tsx
+++ b/src/UsedColors.tsx
@@ -7,6 +7,8 @@ export interface UsedColorsProps {
   showSkeins?: boolean;
   activeColor?: string | null;
   onColorClick?: ((color: string) => void) | null;
+  symbols?: Record<string, string> | null;
+  showSymbols?: boolean;
 }
 
 export default function UsedColors({
@@ -14,7 +16,9 @@ export default function UsedColors({
   usage = {},
   showSkeins = false,
   activeColor = null,
-  onColorClick = null
+  onColorClick = null,
+  symbols = null,
+  showSymbols = false
 }: UsedColorsProps) {
   return (
     <Flex wrap="wrap" gap={2} justify="center">
@@ -39,7 +43,9 @@ export default function UsedColors({
                 borderRadius="4px"
                 m="0 auto"
               />
-              <Text mt={1}>{dmc ? dmc.code : ''}</Text>
+              <Text mt={1}>
+                {dmc ? (showSymbols && symbols ? symbols[dmc.code] : dmc.code) : ''}
+              </Text>
             </Box>
           </Tooltip>
         );

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,4 +5,5 @@ export interface PatternDetails {
   heightIn: number;
   colors: string[];
   colorUsage: Record<string, number>;
+  symbols: Record<string, string>;
 }

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -4,6 +4,39 @@ import { uploadData } from '@aws-amplify/storage';
 import type { Schema } from '../amplify/data/resource';
 import type { PatternDetails } from './types';
 
+export const STITCH_SYMBOLS = [
+  '●','○','■','□','▲','△','▼','▽','◆','◇',
+  '★','☆','✚','✖','✱','✦','✧','✩','✪','✫',
+  '✬','✭','✮','✯','☐','☑','☒','♠','♣','♥',
+  '♦','♢','♤','♧','⌂','♪','♫','♭','♮','♯',
+  '∆','π','Ω','Ψ','Φ','Λ','Θ','Σ','Γ','μ',
+  'λ','ζ','∞','⊥','⊙','⊗','⊕','⊖','⊞','⊟',
+  '◉','◌','◎','◍','◐','◑','◒','◓','◔','◕',
+  '◖','◗','◘','◙','◢','◣','◤','◥','◦','◯',
+  '◻','◼','◽','◾','▣','▤','▥','▦','▧','▨',
+  '▩','▢','◊'
+];
+
+export function hexToDmcCode(hex: string): string | null {
+  const found = DMC_COLORS.find(c => c.hex.toLowerCase() === hex.toLowerCase());
+  return found ? found.code : null;
+}
+
+export function generateSymbolMap(colors: string[]): Record<string, string> {
+  const map: Record<string, string> = {};
+  colors.forEach((hex, idx) => {
+    const code = hexToDmcCode(hex) || hex;
+    const base = STITCH_SYMBOLS[idx];
+    let symbol = base;
+    if (!symbol) {
+      const fallback = idx - STITCH_SYMBOLS.length;
+      symbol = String.fromCharCode(65 + (fallback % 26));
+    }
+    map[code] = symbol;
+  });
+  return map;
+}
+
 const client = generateClient<Schema>();
 
 // Convert hex to RGB array


### PR DESCRIPTION
## Summary
- generate a unique symbol mapping for each project's floss colors
- store symbol mapping on `PatternDetails`
- export symbol constants and helpers
- show/hide symbols in Deep Dive with a toggle
- display symbols in grids and color lists when enabled

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687bc1b083b88324a01ebf21a372d015