### PR TITLE
Update Deep Dive symbol and overlay behavior

### DIFF
--- a/src/DeepDive.tsx
+++ b/src/DeepDive.tsx
@@ -67,7 +67,7 @@ export default function DeepDive() {
             setHover(null);
           }}
         >
-          {done && !selected && (
+          {done && (
             <Box
               position="absolute"
               top={0}
@@ -176,7 +176,7 @@ export default function DeepDive() {
             maxGridPx={maxGridPx}
             completedCells={completedCells}
             symbolMap={pattern.symbols}
-            showSymbols={showSymbols}
+            showSymbols={false}
           />
           <Box position="absolute" top={0} left={0} right={0} bottom={0}>
             {overlays}

--- a/src/UsedColors.tsx
+++ b/src/UsedColors.tsx
@@ -32,19 +32,33 @@ export default function UsedColors({
           ? `${dmc.name} (#${dmc.code})${count ? ` - ${count} stitches` : ''}${skeins}`
           : `${hex}${count ? ` - ${count} stitches` : ''}${skeins}`;
         const dimmed = activeColor && activeColor.toLowerCase() !== hex.toLowerCase();
+        const symbol = dmc && symbols ? symbols[dmc.code] : '';
         return (
           <Tooltip key={hex} label={label} hasArrow>
-            <Box textAlign="center" fontSize="11px" opacity={dimmed ? 0.3 : 1} cursor={onColorClick ? 'pointer' : 'default'} onClick={() => onColorClick && onColorClick(hex)}>
+            <Box
+              textAlign="center"
+              fontSize="11px"
+              opacity={dimmed ? 0.3 : 1}
+              cursor={onColorClick ? 'pointer' : 'default'}
+              onClick={() => onColorClick && onColorClick(hex)}
+            >
               <Box
                 w="24px"
                 h="24px"
                 border="1px solid #ccc"
-                bg={hex}
+                bg={showSymbols ? '#fff' : hex}
+                color={showSymbols ? '#000' : 'inherit'}
                 borderRadius="4px"
                 m="0 auto"
-              />
+                display="flex"
+                alignItems="center"
+                justifyContent="center"
+                fontWeight="bold"
+              >
+                {showSymbols ? symbol : ''}
+              </Box>
               <Text mt={1}>
-                {dmc ? (showSymbols && symbols ? symbols[dmc.code] : dmc.code) : ''}
+                {dmc ? (showSymbols && symbols ? symbol : dmc.code) : ''}
               </Text>
             </Box>
           </Tooltip>


### PR DESCRIPTION
## Summary
- keep section completion checkmarks visible even when another section is open
- restrict the symbol toggle to subsections only
- show symbols in the color key when symbol mode is enabled

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687bd3cb41e883248d4e1284f6382785