### PR TITLE
Fix symbol display in Deep Dive

### DIFF
--- a/src/Grid.tsx
+++ b/src/Grid.tsx
@@ -71,10 +71,13 @@ export default function Grid({
         row.map((color, x) => {
           const dmcLabel = hexToDmc(color) || `(${x + 1}, ${y + 1})`;
           const code = DMC_COLORS.find(c => c.hex.toLowerCase() === (color || '').toLowerCase())?.code;
-          const symbol = showSymbols && code && symbolMap ? symbolMap[code] : '';
           const colorFiltered =
             activeColor &&
             (color || '').toLowerCase() !== activeColor.toLowerCase();
+          const symbol =
+            showSymbols && !colorFiltered && code && symbolMap
+              ? symbolMap[code]
+              : '';
           const dimmed =
             activeCell && !(activeCell.y === y && activeCell.x === x);
           const displayColor = colorFiltered ? null : color;

--- a/src/UsedColors.tsx
+++ b/src/UsedColors.tsx
@@ -57,9 +57,7 @@ export default function UsedColors({
               >
                 {showSymbols ? symbol : ''}
               </Box>
-              <Text mt={1}>
-                {dmc ? (showSymbols && symbols ? symbol : dmc.code) : ''}
-              </Text>
+              <Text mt={1}>{dmc ? dmc.code : ''}</Text>
             </Box>
           </Tooltip>
         );


### PR DESCRIPTION
## Summary
- correct symbols overlay when filtering by color
- show DMC codes under each symbol

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687be312e4cc8324892fba8db409e198