### PR TITLE
Fix Playfair Display SC font

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link href="https://fonts.googleapis.com/css2?family=Playfair+SC&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display+SC&display=swap" rel="stylesheet">
     <title>SnapStitch</title>
   </head>
   <body>

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -32,7 +32,7 @@ export default function Header() {
         <Image src={logo} alt="SnapStitch logo" boxSize="50px" borderRadius="md" mr={3} />
         <Heading
           size="xl"
-          fontFamily="'Playfair SC', serif"
+          fontFamily="'Playfair Display SC', serif"
           letterSpacing="widest"
           color="teal.100"
           textTransform="none"


### PR DESCRIPTION
## Summary
- use the correct Google Fonts URL for Playfair Display SC
- update Header component to use the proper font family

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687bfbe1c70c8324a7fbc03651f8f797