### PR TITLE
Add account menu and route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import Footer from './Footer';
 import DeepDive from './DeepDive';
 import Projects from './Projects';
 import FlossBox from './FlossBox';
+import MyAccount from "./MyAccount";
 import ShoppingList from './ShoppingList';
 import { useNavigate, useLocation } from 'react-router-dom';
 import sample1 from './images/samples/dancer.png';
@@ -149,6 +150,17 @@ export default function App() {
         <Header />
         <Box flex="1">
           <FlossBox />
+        </Box>
+        <Footer />
+      </Box>
+    );
+
+  if (location.pathname === "/my-account") {
+    return (
+      <Box minH="100vh" minW="100vw" display="flex" flexDirection="column">
+        <Header />
+        <Box flex="1">
+          <MyAccount />
         </Box>
         <Footer />
       </Box>

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -9,6 +9,10 @@ import {
   Modal,
   ModalOverlay,
   ModalContent,
+  Menu,
+  MenuButton,
+  MenuList,
+  MenuItem,
   useDisclosure,
 } from '@chakra-ui/react';
 import { FiUser } from 'react-icons/fi';
@@ -45,42 +49,38 @@ export default function Header() {
           Thread
         </Heading>
         <Spacer />
-        {user && (
-          <>
-            <Button
-              bg="yellow.100" 
-              color="green.900" 
-              _hover={{ bg: "green.900", color: "yellow.100", borderColor: "yellow.100"}}
+        {user ? (
+          <Menu>
+            <MenuButton
+              as={Button}
+              bg="yellow.100"
+              color="green.900"
+              _hover={{ bg: "green.900", color: "yellow.100", borderColor: "yellow.100" }}
               size="sm"
               mr={2}
-              onClick={() => navigate('/projects')}
             >
               <FiUser fontSize="1.2rem" />
-            </Button>
-
-            <Button
-              bg="yellow.100" 
-              color="green.900" 
-              _hover={{ bg: "green.900", color: "yellow.100", borderColor: "yellow.100"}}
-              size="sm"
-              mr={2}
-              onClick={() => navigate('/projects')}
-            >
-              My Projects 
-            </Button>
-            <Button
-              colorScheme="teal"
-              size="sm"
-              mr={2}
-              onClick={() => navigate('/floss-box')}
-            >
-              Floss Box
-            </Button>
-          </>
+            </MenuButton>
+            <MenuList bg="green.900" color="yellow.100" borderColor="yellow.100">
+              <MenuItem bg="green.900" _hover={{ bg: "yellow.100", color: "green.900" }} onClick={() => navigate('/projects')}>
+                Projects
+              </MenuItem>
+              <MenuItem bg="green.900" _hover={{ bg: "yellow.100", color: "green.900" }} onClick={() => navigate('/floss-box')}>
+                Floss Box
+              </MenuItem>
+              <MenuItem bg="green.900" _hover={{ bg: "yellow.100", color: "green.900" }} onClick={() => navigate('/my-account')}>
+                My Account
+              </MenuItem>
+              <MenuItem bg="green.900" _hover={{ bg: "yellow.100", color: "green.900" }} onClick={signOut}>
+                Logout
+              </MenuItem>
+            </MenuList>
+          </Menu>
+        ) : (
+          <Button colorScheme="teal" size="sm" onClick={onOpen}>
+            Join or Sign in
+          </Button>
         )}
-        <Button colorScheme="teal" size="sm" onClick={user ? signOut : onOpen}>
-          {user ? 'Logout' : 'Join or Sign in'}
-        </Button>
       </Flex>
       <Modal isOpen={isOpen} onClose={onClose} isCentered>
         <ModalOverlay />

--- a/src/MyAccount.tsx
+++ b/src/MyAccount.tsx
@@ -1,0 +1,9 @@
+import { Box } from '@chakra-ui/react';
+
+export default function MyAccount() {
+  return (
+    <Box p={4}>
+      My Account experience coming soon.
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add MyAccount page
- add `/my-account` route
- use a Chakra Menu for the user icon with links to Projects, Floss Box, My Account and Logout

## Testing
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c3232d0708324bc98d4864a3c11f6