### PR TITLE
Fix pathfinder layout and step numbering

### DIFF
--- a/src/Grid.tsx
+++ b/src/Grid.tsx
@@ -23,6 +23,8 @@ export interface GridProps {
   completedCells?: Set<string> | null;
   /** Specific cells to keep active when activeColor is set */
   activeCells?: Set<string> | null;
+  /** Optional labels for specific cells keyed by "y-x" */
+  labels?: Record<string, string> | null;
   symbolMap?: Record<string, string> | null;
   showSymbols?: boolean;
 }
@@ -39,6 +41,7 @@ export default function Grid({
   markComplete = false,
   completedCells = null,
   activeCells = null,
+  labels = null,
   symbolMap = null,
   showSymbols = false,
 }: GridProps) {
@@ -103,6 +106,7 @@ export default function Grid({
               boxSizing="border-box"
               cursor="pointer"
               opacity={dimmed ? 0.3 : 1}
+              position="relative"
               display="flex"
               alignItems="center"
               justifyContent="center"
@@ -117,6 +121,17 @@ export default function Grid({
               title={dmcLabel}
             >
               {isComplete ? "X" : symbol}
+              {labels && labels[cellKey] && (
+                <Box
+                  position="absolute"
+                  top={0}
+                  left={1}
+                  fontSize="xs"
+                  color="#000"
+                >
+                  {labels[cellKey]}
+                </Box>
+              )}
             </Box>
           );
         }),

--- a/src/Pathfinder.tsx
+++ b/src/Pathfinder.tsx
@@ -2,8 +2,6 @@ import { useMemo, useState } from "react";
 import { Box, Button, Heading } from "@chakra-ui/react";
 import { useLocation, useNavigate } from "react-router-dom";
 import Grid from "./Grid";
-import Header from "./Header";
-import Footer from "./Footer";
 import type { PatternDetails } from "./types";
 
 interface Path {
@@ -117,15 +115,26 @@ export default function Pathfinder() {
   if (!pattern) return <Box p={4}>No pattern selected.</Box>;
   if (!current || !step) return <Box p={4}>No path found.</Box>;
 
-  const activeCells = new Set(current.cells.map((c) => `${c.y}-${c.x}`));
+  const activeCells = new Set(
+    current.cells.slice(0, stepIdx + 1).map((c) => `${c.y}-${c.x}`),
+  );
   const size = pattern.fabricCount;
   const subGrid = extractSubGrid(pattern.grid, step, size);
   const half = Math.floor(size / 2);
   const subActive = { y: half, x: half };
+  const subLabels: Record<string, string> = {};
+  for (let i = 0; i <= stepIdx; i++) {
+    const c = current.cells[i];
+    const subY = c.y - (step.y - half);
+    const subX = c.x - (step.x - half);
+    if (subY >= 0 && subY < size && subX >= 0 && subX < size) {
+      subLabels[`${subY}-${subX}`] = String(i + 1);
+    }
+  }
+  const subActiveCells = new Set(Object.keys(subLabels));
 
   return (
     <Box minH="100vh" minW="100vw" display="flex" flexDirection="column">
-      <Header />
       <Box flex="1" p={4} textAlign="center">
         <Heading size="md" mb={4}>
           Pathfinder
@@ -144,7 +153,8 @@ export default function Pathfinder() {
             showGrid={true}
             activeColor={current.color}
             activeCell={subActive}
-            activeCells={new Set([`${subActive.y}-${subActive.x}`])}
+            activeCells={subActiveCells}
+            labels={subLabels}
             maxGridPx={200}
           />
         </Box>
@@ -155,7 +165,6 @@ export default function Pathfinder() {
           Back
         </Button>
       </Box>
-      <Footer />
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- avoid duplicated Header/Footer in pathfinder
- show progress path instead of entire region
- label steps in zoomed grid for better guidance
- extend Grid to support per-cell labels

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint . --ext ts,tsx`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687d517425a4832486af0b48703ea138