### PR TITLE
Enable pathPlanner function URL

### DIFF
--- a/amplify/pathPlanner/resource.ts
+++ b/amplify/pathPlanner/resource.ts
@@ -1,3 +1,3 @@
 import { defineFunction } from '@aws-amplify/backend';
 
-export const pathPlanner = defineFunction();
+export const pathPlanner = defineFunction().addFunctionUrl();


### PR DESCRIPTION
## Summary
- configure pathPlanner lambda with `addFunctionUrl` in Amplify backend

## Testing
- `npm run build`
- `npx ampx sandbox --once --outputs-out-dir .` *(fails: InvalidCredentialError)*

------
https://chatgpt.com/codex/tasks/task_e_687d8fb3810c8324b51388f4aac522f9