### PR TITLE
Fix Amplify function url setup

### DIFF
--- a/amplify/pathPlanner/resource.ts
+++ b/amplify/pathPlanner/resource.ts
@@ -1,3 +1,21 @@
 import { defineFunction } from '@aws-amplify/backend';
+import { FunctionUrlAuthType } from 'aws-cdk-lib/aws-lambda';
+import type {
+  ConstructFactory,
+  ResourceProvider,
+  FunctionResources,
+  ResourceAccessAcceptorFactory,
+  StackProvider,
+} from '@aws-amplify/plugin-types';
 
-export const pathPlanner = defineFunction().addFunctionUrl();
+const base = defineFunction();
+type PathPlannerInstance = ReturnType<typeof base.getInstance>;
+
+export const pathPlanner: ConstructFactory<PathPlannerInstance> = {
+  ...base,
+  getInstance: (props) => {
+    const instance = base.getInstance(props);
+    instance.resources.lambda.addFunctionUrl({ authType: FunctionUrlAuthType.NONE });
+    return instance;
+  },
+};

--- a/src/Pathfinder.tsx
+++ b/src/Pathfinder.tsx
@@ -5,6 +5,13 @@ import Grid from './Grid';
 import type { PatternDetails } from './types';
 import outputs from '../amplify_outputs.json';
 
+interface AmplifyOutputs {
+  pathPlanner?: {
+    functionUrl: string;
+  };
+  [key: string]: unknown;
+}
+
 interface Segment {
   color: string;
   path: [number, number][];
@@ -23,7 +30,10 @@ export default function Pathfinder() {
 
   const handleSubmit = async () => {
     if (!pattern) return;
-    const url = (outputs as any).pathPlanner?.functionUrl;
+    const url = (outputs as AmplifyOutputs).pathPlanner?.functionUrl;
+    if (!url) {
+      throw new Error('pathPlanner functionUrl not defined');
+    }
     const res = await fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- update Pathfinder handle to require function URL
- extend pathPlanner resource to attach function URL via CDK
- type outputs to avoid lint errors

## Testing
- `npm run lint`
- `npx tsc -p amplify/tsconfig.json`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d9487c2f4832486bc8e4c61b6c548