### PR TITLE
Expose function url

### DIFF
--- a/amplify/pathPlanner/resource.ts
+++ b/amplify/pathPlanner/resource.ts
@@ -16,6 +16,8 @@ export const pathPlanner: ConstructFactory<PathPlannerInstance> = {
   getInstance: (props) => {
     const instance = base.getInstance(props);
     instance.resources.lambda.addFunctionUrl({ authType: FunctionUrlAuthType.NONE });
+    // Expose the function URL via amplify_outputs.json for frontend use
+    props.outputs.functionUrl = instance.resources.lambda.functionUrl!.url;
     return instance;
   },
 };


### PR DESCRIPTION
## Summary
- add pathPlanner function URL to Amplify outputs

## Testing
- `npm run lint` *(fails: couldn't find ESLint config)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687d9f9ac7548324a87613c8ce276696