### PR TITLE
Enable CORS for pathPlanner lambda

### DIFF
--- a/amplify/pathPlanner/handler.ts
+++ b/amplify/pathPlanner/handler.ts
@@ -89,9 +89,17 @@ export const handler = async (event: { body?: string }) => {
     const maxStitches = body.max_stitches ?? body.maxStitches ?? 150;
     const maxJump = body.max_jump ?? body.maxJump ?? 5;
     const result = planStitchingSegments(grid, maxStitches, maxJump);
-    return { statusCode: 200, body: JSON.stringify(result) };
+    return {
+      statusCode: 200,
+      headers: { 'Access-Control-Allow-Origin': '*' },
+      body: JSON.stringify(result),
+    };
   } catch (err) {
     const message = err instanceof Error ? err.message : 'unknown error';
-    return { statusCode: 500, body: JSON.stringify({ error: message }) };
+    return {
+      statusCode: 500,
+      headers: { 'Access-Control-Allow-Origin': '*' },
+      body: JSON.stringify({ error: message }),
+    };
   }
 };

--- a/amplify/pathPlanner/resource.ts
+++ b/amplify/pathPlanner/resource.ts
@@ -11,6 +11,11 @@ export const pathPlanner: ConstructFactory<PathPlannerInstance> = {
     const instance = base.getInstance(props);
     const fnUrl = instance.resources.lambda.addFunctionUrl({
       authType: FunctionUrlAuthType.NONE,
+      cors: {
+        allowedOrigins: ['*'],
+        allowedMethods: ['GET', 'POST', 'OPTIONS'],
+        allowedHeaders: ['*'],
+      },
     });
     props.outputStorageStrategy.addBackendOutputEntry('pathPlanner', {
       version: '1',

--- a/src/Pathfinder.tsx
+++ b/src/Pathfinder.tsx
@@ -7,7 +7,10 @@ import outputs from '../amplify_outputs.json';
 
 interface AmplifyOutputs {
   pathPlanner?: {
-    functionUrl: string;
+    version: string;
+    payload: {
+      functionUrl: string;
+    };
   };
   [key: string]: unknown;
 }
@@ -30,7 +33,7 @@ export default function Pathfinder() {
 
   const handleSubmit = async () => {
     if (!pattern) return;
-    const url = (outputs as AmplifyOutputs).pathPlanner?.functionUrl;
+    const url = (outputs as AmplifyOutputs).pathPlanner?.payload.functionUrl;
     if (!url) {
       console.error('pathPlanner functionUrl not defined');
       return;


### PR DESCRIPTION
## Summary
- enable CORS for the Lambda URL in `amplify/pathPlanner/resource.ts`
- include CORS headers from the handler
- update Pathfinder type expectations for new output structure

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687db7d4a4088324ac6050b25c6cdfec