### PR TITLE
Fix HttpMethod enum in path planner

### DIFF
--- a/amplify/pathPlanner/resource.ts
+++ b/amplify/pathPlanner/resource.ts
@@ -1,5 +1,5 @@
 import { defineFunction } from '@aws-amplify/backend';
-import { FunctionUrlAuthType } from 'aws-cdk-lib/aws-lambda';
+import { FunctionUrlAuthType, HttpMethod } from 'aws-cdk-lib/aws-lambda';
 import type { ConstructFactory } from '@aws-amplify/plugin-types';
 
 const base = defineFunction();
@@ -13,7 +13,7 @@ export const pathPlanner: ConstructFactory<PathPlannerInstance> = {
       authType: FunctionUrlAuthType.NONE,
       cors: {
         allowedOrigins: ['*'],
-        allowedMethods: ['GET', 'POST', 'OPTIONS'],
+        allowedMethods: [HttpMethod.GET, HttpMethod.POST, HttpMethod.OPTIONS],
         allowedHeaders: ['*'],
       },
     });


### PR DESCRIPTION
## Summary
- use `HttpMethod` enum for function URL CORS settings in pathPlanner

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: missing dependencies for TypeScript build)*

------
https://chatgpt.com/codex/tasks/task_e_687dbb72f0e883249ba7c8916d2b3f87