### PR TITLE
Fix lambda function url method typing

### DIFF
--- a/amplify/pathPlanner/resource.ts
+++ b/amplify/pathPlanner/resource.ts
@@ -13,7 +13,7 @@ export const pathPlanner: ConstructFactory<PathPlannerInstance> = {
       authType: FunctionUrlAuthType.NONE,
       cors: {
         allowedOrigins: ['*'],
-        allowedMethods: [HttpMethod.GET, HttpMethod.POST, HttpMethod.OPTIONS],
+        allowedMethods: ['GET', 'POST', 'OPTIONS'] as unknown as HttpMethod[],
         allowedHeaders: ['*'],
       },
     });


### PR DESCRIPTION
## Summary
- fix typing for Lambda function url CORS options

## Testing
- `npx tsc -p amplify`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687dc21213148324a49d5a0b4f283885