### PR TITLE
Display lambda result on pathfinder page

### DIFF
--- a/amplify/path-finder/handler.ts
+++ b/amplify/path-finder/handler.ts
@@ -1,5 +1,3 @@
-import { APIGatewayProxyEvent } from 'aws-lambda';
-
-export const handler = async (event: APIGatewayProxyEvent) => {
+export const handler = async () => {
   return "Hello from my first function!";
 };

--- a/src/Pathfinder.tsx
+++ b/src/Pathfinder.tsx
@@ -1,5 +1,15 @@
 import { Box } from '@chakra-ui/react';
+import { useEffect, useState } from 'react';
 
 export default function Pathfinder() {
-  return <Box p={4}>Pathfinder placeholder.</Box>;
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    fetch('/path-finder')
+      .then(res => res.text())
+      .then(text => setMessage(text))
+      .catch(() => setMessage('Error calling function'));
+  }, []);
+
+  return <Box p={4}>{message || 'Loading...'}</Box>;
 }


### PR DESCRIPTION
## Summary
- adjust lambda handler for lint
- invoke the `path-finder` function from the Pathfinder page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687ec722708c832492d455d77802416d