### PR TITLE
Implement stitching path planner

### DIFF
--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -2,11 +2,11 @@ import { defineBackend } from '@aws-amplify/backend';
 import { auth } from './auth/resource';
 import { data } from './data/resource';
 import { storage } from './storage/resource';
-import { myFirstFunction } from './path-finder/resource';
+import { pathFinder } from './path-finder/resource';
 
 defineBackend({
   auth,
   data,
   storage,
-  myFirstFunction
+  pathFinder
 });

--- a/amplify/path-finder/handler.ts
+++ b/amplify/path-finder/handler.ts
@@ -1,3 +1,83 @@
-export const handler = async () => {
-  return "Hello from my first function!";
+export type Coord = [number, number];
+
+function manhattan(a: Coord, b: Coord): number {
+  return Math.abs(a[0] - b[0]) + Math.abs(a[1] - b[1]);
+}
+
+function key(c: Coord): string {
+  return `${c[0]},${c[1]}`;
+}
+
+function parseKey(k: string): Coord {
+  const [y, x] = k.split(',').map(n => parseInt(n, 10));
+  return [y, x];
+}
+
+function bfsCluster(remaining: Set<string>, start: Coord, maxJump: number, maxStitches: number): Coord[] {
+  const queue: Coord[] = [start];
+  const visited = new Set<string>([key(start)]);
+  const path: Coord[] = [start];
+
+  while (queue.length && path.length < maxStitches) {
+    const current = queue.shift()!;
+    for (const cellKey of Array.from(remaining)) {
+      if (!visited.has(cellKey)) {
+        const cell = parseKey(cellKey);
+        if (manhattan(current, cell) <= maxJump) {
+          visited.add(cellKey);
+          queue.push(cell);
+          path.push(cell);
+          if (path.length >= maxStitches) break;
+        }
+      }
+    }
+  }
+  return path;
+}
+
+function segmentColorGroup(cells: Coord[], maxStitches: number, maxJump: number): Coord[][] {
+  const segments: Coord[][] = [];
+  const remaining = new Set<string>(cells.map(key));
+
+  while (remaining.size) {
+    const firstKey = remaining.values().next().value as string;
+    const start = parseKey(firstKey);
+    const seg = bfsCluster(remaining, start, maxJump, maxStitches);
+    seg.forEach(c => remaining.delete(key(c)));
+    segments.push(seg);
+  }
+
+  return segments;
+}
+
+function planStitchingSegments(grid: string[][], maxStitches = 150, maxJump = 5) {
+  const colorGroups: Record<string, Coord[]> = {};
+  for (let r = 0; r < grid.length; r++) {
+    for (let c = 0; c < (grid[0]?.length || 0); c++) {
+      const color = grid[r][c];
+      if (!colorGroups[color]) colorGroups[color] = [];
+      colorGroups[color].push([r, c]);
+    }
+  }
+
+  const allSegments: { color: string; path: Coord[] }[] = [];
+  for (const color of Object.keys(colorGroups)) {
+    const segs = segmentColorGroup(colorGroups[color], maxStitches, maxJump);
+    segs.forEach(s => allSegments.push({ color, path: s }));
+  }
+  return allSegments;
+}
+
+export const handler = async (event: unknown) => {
+  try {
+    const e = event as { body?: string } & Record<string, unknown>;
+    const body = e.body ? JSON.parse(e.body) : (e as Record<string, unknown>);
+    const grid = body.grid as string[][];
+    const maxStitches = body.max_stitches ?? 150;
+    const maxJump = body.max_jump ?? 5;
+    const result = planStitchingSegments(grid, maxStitches, maxJump);
+    return { statusCode: 200, body: JSON.stringify(result) };
+  } catch (err) {
+    return { statusCode: 500, body: JSON.stringify({ error: String(err) }) };
+  }
 };

--- a/amplify/path-finder/resource.ts
+++ b/amplify/path-finder/resource.ts
@@ -1,6 +1,6 @@
 import { defineFunction } from "@aws-amplify/backend";
 
-export const myFirstFunction = defineFunction({
+export const pathFinder = defineFunction({
   name: "path-finder",
   entry: "./handler.ts"
 });

--- a/src/Pathfinder.tsx
+++ b/src/Pathfinder.tsx
@@ -1,15 +1,91 @@
-import { Box } from '@chakra-ui/react';
-import { useEffect, useState } from 'react';
+import { Box, Button, NumberInput, NumberInputField, FormControl, FormLabel, VStack } from '@chakra-ui/react';
+import { useState, useEffect, useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
+import Grid from './Grid';
+import type { PatternDetails } from './types';
+
+interface Segment { color: string; path: [number, number][]; }
 
 export default function Pathfinder() {
-  const [message, setMessage] = useState('');
+  const location = useLocation();
+  const { pattern } = (location.state as { pattern?: PatternDetails } | undefined) || {};
+  const [maxStitches, setMaxStitches] = useState<number>(150);
+  const [maxJump, setMaxJump] = useState<number>(5);
+  const [segments, setSegments] = useState<Segment[] | null>(null);
+  const [displayGrid, setDisplayGrid] = useState<string[][]>([]);
+
+  const baseGrid = useMemo(() => pattern?.grid ?? [], [pattern]);
 
   useEffect(() => {
-    fetch('/path-finder')
-      .then(res => res.text())
-      .then(text => setMessage(text))
-      .catch(() => setMessage('Error calling function'));
-  }, []);
+    if (!pattern) return;
+    setDisplayGrid(baseGrid.map(row => row.map(() => '#ffffff')));
+  }, [pattern, baseGrid]);
 
-  return <Box p={4}>{message || 'Loading...'}</Box>;
+  const animateSegments = (segs: Segment[]) => {
+    if (!pattern) return;
+    const working = baseGrid.map(row => row.map(() => '#ffffff'));
+    setDisplayGrid(working.map(r => [...r]));
+    let segIdx = 0;
+    let stitchIdx = 0;
+    const step = () => {
+      if (segIdx >= segs.length) return;
+      const seg = segs[segIdx];
+      if (stitchIdx < seg.path.length) {
+        const [y, x] = seg.path[stitchIdx];
+        working[y][x] = seg.color;
+        setDisplayGrid(working.map(r => [...r]));
+        stitchIdx++;
+        setTimeout(step, 100);
+      } else {
+        segIdx++;
+        stitchIdx = 0;
+        setTimeout(step, 300);
+      }
+    };
+    step();
+  };
+
+  const handleSubmit = async () => {
+    if (!pattern) return;
+    const res = await fetch('/pathFinder', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ grid: pattern.grid, max_stitches: maxStitches, max_jump: maxJump })
+    });
+    const data = await res.json();
+    setSegments(data);
+    animateSegments(data);
+  };
+
+  if (!pattern) return <Box p={4}>No pattern data.</Box>;
+
+  return (
+    <Box p={4}>
+      <VStack align="start" spacing={4} mb={4}>
+        <FormControl>
+          <FormLabel>Max Stitches</FormLabel>
+          <NumberInput value={maxStitches} onChange={(v) => setMaxStitches(parseInt(v))} min={1}>
+            <NumberInputField />
+          </NumberInput>
+        </FormControl>
+        <FormControl>
+          <FormLabel>Max Jump</FormLabel>
+          <NumberInput value={maxJump} onChange={(v) => setMaxJump(parseInt(v))} min={1}>
+            <NumberInputField />
+          </NumberInput>
+        </FormControl>
+        <Button onClick={handleSubmit} bg="green.900" color="yellow.100">Submit</Button>
+      </VStack>
+      <Grid grid={displayGrid} showGrid maxGridPx={500} />
+      {segments && (
+        <Box mt={4} fontSize="sm">
+          {segments.map((s, i) => (
+            <Box key={i} mb={2}>
+              <strong>Segment {i + 1} - {s.color}</strong>: {s.path.map(p => `(${p[0]},${p[1]})`).join(' -> ')}
+            </Box>
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
 }


### PR DESCRIPTION
## Summary
- implement path finding logic in the `path-finder` Lambda
- overhaul Pathfinder page with inputs for max stitches and jump
- animate grid filling according to returned segments
- ensure correct function route

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687ec9c6b0108324ad60e653a86b9181