### PR TITLE
Save stitch paths for project

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -12,6 +12,7 @@ const schema = a.schema({
   pathFinder: a
     .query()
     .arguments({
+      projectID: a.string(),
       grid: a.string().array().array(),
     })
     .returns(a.string())

--- a/amplify/functions/path-finder/handler.ts
+++ b/amplify/functions/path-finder/handler.ts
@@ -1,10 +1,92 @@
 import type { Schema } from "../../data/resource";
+import { generateClient } from "@aws-amplify/backend";
+
+type Coord = [number, number];
+
+function manhattan(a: Coord, b: Coord): number {
+  return Math.abs(a[0] - b[0]) + Math.abs(a[1] - b[1]);
+}
+
+function bfsCluster(
+  remaining: Set<string>,
+  start: Coord,
+  maxJump: number,
+  maxStitches: number,
+): Coord[] {
+  const queue: Coord[] = [start];
+  const segment: Coord[] = [start];
+  remaining.delete(start.join(","));
+
+  while (queue.length && segment.length < maxStitches) {
+    const current = queue.shift()!;
+    for (const cell of Array.from(remaining)) {
+      const [r, c] = cell.split(",").map(Number) as Coord;
+      if (manhattan(current, [r, c]) <= maxJump) {
+        queue.push([r, c]);
+        segment.push([r, c]);
+        remaining.delete(cell);
+        if (segment.length >= maxStitches) break;
+      }
+    }
+  }
+  return segment;
+}
+
+function segmentColorGroup(
+  cells: Coord[],
+  maxStitches: number,
+  maxJump: number,
+): Coord[][] {
+  const remaining = new Set(cells.map(c => c.join(",")));
+  const segments: Coord[][] = [];
+
+  while (remaining.size) {
+    const first = Array.from(remaining)[0];
+    const start = first.split(",").map(Number) as Coord;
+    const seg = bfsCluster(remaining, start, maxJump, maxStitches);
+    segments.push(seg);
+  }
+
+  return segments;
+}
+
+function planSegments(
+  grid: string[][],
+  maxStitches: number,
+  maxJump: number,
+): { color: string; path: Coord[] }[] {
+  const colorGroups = new Map<string, Coord[]>();
+  for (let r = 0; r < grid.length; r++) {
+    for (let c = 0; c < grid[r].length; c++) {
+      const color = grid[r][c];
+      if (!color) continue;
+      if (!colorGroups.has(color)) colorGroups.set(color, []);
+      colorGroups.get(color)!.push([r, c]);
+    }
+  }
+
+  const allSegments: { color: string; path: Coord[] }[] = [];
+  for (const [color, coords] of colorGroups.entries()) {
+    const segs = segmentColorGroup(coords, maxStitches, maxJump);
+    for (const seg of segs) {
+      allSegments.push({ color, path: seg });
+    }
+  }
+  return allSegments;
+}
+
+const client = generateClient<Schema>();
 
 export const handler: Schema["pathFinder"]["functionHandler"] = async (event) => {
-  const { grid } = event.arguments;
+  const { grid, projectID, max_stitches = 150, max_jump = 5 } = event.arguments as {
+    grid: string[][];
+    projectID: string;
+    max_stitches?: number;
+    max_jump?: number;
+  };
 
-if (!grid) {
-    return "Missing 'grid' argument";
+  if (!grid || !projectID) {
+    return "Missing 'grid' or 'projectID' argument";
   }
 
   for (let i = 0; i < grid.length; i++) {
@@ -13,8 +95,21 @@ if (!grid) {
     }
   }
 
-  const rows = grid.length;
-  const cols = grid[0]?.length ?? 0;
+  const segments = planSegments(grid, max_stitches, max_jump);
 
-  return `There are ${rows} rows and ${cols} columns.`;
+  let segmentIndex = 0;
+  for (const seg of segments) {
+    segmentIndex += 1;
+    const pathXs = seg.path.map(([r]) => r);
+    const pathYs = seg.path.map(([_, c]) => c);
+    await client.models.Path.create({
+      projectID,
+      segmentID: segmentIndex.toString(),
+      color: seg.color,
+      pathXs,
+      pathYs,
+    });
+  }
+
+  return `Saved ${segmentIndex} segments`;
 };

--- a/src/Pathfinder.tsx
+++ b/src/Pathfinder.tsx
@@ -11,20 +11,14 @@ const client = generateClient<Schema>();
 
 interface LocationState {
   pattern?: PatternDetails;
+  id?: string;
 }
 
 
-function isStringGrid(value: unknown): value is string[][] {
-  return Array.isArray(value) &&
-    value.every(row =>
-      Array.isArray(row) &&
-      row.every(cell => typeof cell === "string")
-    );
-}
 
 export default function Pathfinder() {
   const location = useLocation();
-  const { pattern } = (location.state as LocationState) || {};
+  const { pattern, id } = (location.state as LocationState) || {};
   const [result, setResult] = useState<string | null>(null);
 
 
@@ -36,7 +30,10 @@ export default function Pathfinder() {
         return;
       }
       try {
-        const response = await client.queries.pathFinder({ grid: pattern.grid });
+        const response = await client.queries.pathFinder({
+          grid: pattern.grid,
+          projectID: id ?? "",
+        });
 
         // Full logging for visibility
         console.log("Full response from pathFinder:", response);
@@ -57,7 +54,11 @@ export default function Pathfinder() {
 
   return (
     <Box p={4}>
-      <Text>`There are {pattern.grid.length} rows and {pattern.grid[0].length} columns.`;</Text>
+      {pattern && (
+        <Text>
+          {`There are ${pattern.grid.length} rows and ${pattern.grid[0].length} columns.`}
+        </Text>
+      )}
       <Text>Pathfinder result: {result ?? "Loading..."}</Text>
     </Box>
   );

--- a/src/Projects.tsx
+++ b/src/Projects.tsx
@@ -414,7 +414,7 @@ export default function Projects() {
                       navigate("/shopping-list", { state: { pattern } })
                     }
                     onPathfinder={() =>
-                      navigate("/pathfinder", { state: { pattern } })
+                      navigate("/pathfinder", { state: { pattern, id: p.id } })
                     }
                     onDelete={() => deleteProject(p)}
                   />
@@ -570,7 +570,7 @@ export default function Projects() {
                           navigate("/shopping-list", { state: { pattern } })
                         }
                         onPathfinder={() =>
-                          navigate("/pathfinder", { state: { pattern } })
+                          navigate("/pathfinder", { state: { pattern, id: p.id } })
                         }
                         onDelete={() => deleteProject(p)}
                       />


### PR DESCRIPTION
## Summary
- pass project ID with grid to the `pathFinder` API
- implement path segmentation in the path-finder Lambda
- store each segment as a `Path` record
- update UI to provide project IDs to Pathfinder

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68830874a5c883249fbbff1e42f12c5d