### PR TITLE
Fix unauthorized pathfinder calls

### DIFF
--- a/src/Pathfinder.tsx
+++ b/src/Pathfinder.tsx
@@ -7,7 +7,8 @@ import { generateClient } from "aws-amplify/api";
 import type { Schema } from "../amplify/data/resource";
 import type { PatternDetails } from "./types";
 
-const client = generateClient<Schema>();
+// Use explicit auth mode so requests include the user's JWT
+const client = generateClient<Schema>({ authMode: 'userPool' });
 
 interface LocationState {
   pattern?: PatternDetails;


### PR DESCRIPTION
## Summary
- set authMode to `userPool` for API calls in `Pathfinder`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688522a19c4483249517bff96f70c0a4